### PR TITLE
Escape colon in zsh completion help

### DIFF
--- a/src/shells/zsh.rs
+++ b/src/shells/zsh.rs
@@ -463,7 +463,8 @@ fn write_positionals_of(p: &App) -> String {
                 .help
                 .map_or("".to_owned(), |v| " -- ".to_owned() + v)
                 .replace("[", "\\[")
-                .replace("]", "\\]"),
+                .replace("]", "\\]")
+                .replace(":", "\\:"),
             action = arg
                 .possible_vals
                 .as_ref()


### PR DESCRIPTION
Fixes https://github.com/sharkdp/fd/issues/487.

Originally opened towards [`clap repository`](https://github.com/clap-rs/clap/pull/1555).